### PR TITLE
feat: consumer bearer auth + history APIs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -31,6 +31,38 @@ curl -X POST http://localhost:8080/api/chat \
   }'
 ```
 
+Consumer token + analysis endpoint example:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:8080/api/consumer/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "appId": "varutri-mobile",
+    "deviceId": "android-test-device-001",
+    "platform": "ANDROID",
+    "appVersion": "1.0.0"
+  }' | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p')
+
+curl -X POST http://localhost:8080/api/consumer/analyze \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{
+    "channel": "WHATSAPP",
+    "payload": {
+      "text": "Urgent KYC update required, share OTP now",
+      "senderId": "+919000000001"
+    },
+    "metadata": {
+      "platform": "ANDROID",
+      "sourceApp": "whatsapp",
+      "locale": "en_IN"
+    }
+  }'
+
+curl -X GET "http://localhost:8080/api/consumer/history?limit=10" \
+  -H "Authorization: Bearer ${TOKEN}"
+```
+
 ## Configuration
 
 Edit `src/main/resources/application.properties`:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,54 @@ x-api-key: Your_api_key
 Content-Type: application/json
 ```
 
-### GET /health
+### POST /api/consumer/analyze
+
+Consumer-facing suspicious content analysis endpoint for mobile apps, browser extensions, and share flows.
+
+First get a consumer bearer token:
+
+```json
+POST /api/consumer/auth/token
+{
+	"appId": "varutri-mobile",
+	"deviceId": "device-abc-123",
+	"platform": "ANDROID",
+	"appVersion": "1.0.0"
+}
+```
+
+Then call consumer endpoints using:
+
+```
+Authorization: Bearer <accessToken>
+```
+
+Example request:
+```json
+{
+	"channel": "SMS",
+	"payload": {
+		"text": "You won 25 lakh. Send 5000 to claim now.",
+		"senderId": "+919876543210",
+		"url": "http://claim-prize-now.example"
+	},
+	"metadata": {
+		"platform": "ANDROID",
+		"sourceApp": "messages",
+		"locale": "en_IN"
+	}
+}
+```
+
+### GET /api/consumer/history
+
+List recent consumer analyses.
+
+### GET /api/consumer/history/{sessionId}
+
+Get detailed timeline and extracted indicators for one consumer session.
+
+### GET /api/health
 
 Health check endpoint
 

--- a/src/main/java/com/varutri/honeypot/config/SecurityConfig.java
+++ b/src/main/java/com/varutri/honeypot/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.varutri.honeypot.config;
 
 import com.varutri.honeypot.security.ApiKeyFilter;
+import com.varutri.honeypot.security.ConsumerTokenFilter;
 import com.varutri.honeypot.security.RateLimitFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final ApiKeyFilter apiKeyFilter;
+    private final ConsumerTokenFilter consumerTokenFilter;
     private final RateLimitFilter rateLimitFilter;
 
     @Bean
@@ -38,8 +40,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 // Add rate limit filter first (blocks abusive requests early)
                 .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
+                // Then consumer token filter for /api/consumer/**
+                .addFilterAfter(consumerTokenFilter, RateLimitFilter.class)
                 // Then API key filter (validates authentication)
-                .addFilterAfter(apiKeyFilter, RateLimitFilter.class);
+                .addFilterAfter(apiKeyFilter, ConsumerTokenFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/varutri/honeypot/controller/ConsumerAuthController.java
+++ b/src/main/java/com/varutri/honeypot/controller/ConsumerAuthController.java
@@ -1,0 +1,39 @@
+package com.varutri.honeypot.controller;
+
+import com.varutri.honeypot.dto.ApiResponse;
+import com.varutri.honeypot.dto.ConsumerAuthTokenRequest;
+import com.varutri.honeypot.dto.ConsumerAuthTokenResponse;
+import com.varutri.honeypot.service.security.ConsumerTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Consumer auth controller for issuing short-lived bearer tokens.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/consumer/auth")
+@RequiredArgsConstructor
+public class ConsumerAuthController {
+
+    private final ConsumerTokenService consumerTokenService;
+
+    /**
+     * Exchange app/device identity for short-lived bearer token.
+     */
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<ConsumerAuthTokenResponse>> issueToken(
+            @Valid @RequestBody ConsumerAuthTokenRequest request) {
+
+        log.info("Consumer token requested for appId={}, platform={}", request.getAppId(), request.getPlatform());
+        ConsumerAuthTokenResponse response = consumerTokenService.issueToken(request);
+
+        return ApiResponse.ok(response, "Consumer token issued successfully");
+    }
+}

--- a/src/main/java/com/varutri/honeypot/controller/ConsumerController.java
+++ b/src/main/java/com/varutri/honeypot/controller/ConsumerController.java
@@ -1,0 +1,74 @@
+package com.varutri.honeypot.controller;
+
+import com.varutri.honeypot.dto.ApiResponse;
+import com.varutri.honeypot.dto.ConsumerAnalysisResponse;
+import com.varutri.honeypot.dto.ConsumerHistoryDetailResponse;
+import com.varutri.honeypot.dto.ConsumerHistoryItemResponse;
+import com.varutri.honeypot.dto.ConsumerSignalRequest;
+import com.varutri.honeypot.service.core.ConsumerHistoryService;
+import com.varutri.honeypot.service.core.ConsumerSignalService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Consumer-facing ingestion controller.
+ * Supports channel-aware suspicious content analysis for mobile and browser clients.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/consumer")
+@RequiredArgsConstructor
+public class ConsumerController {
+
+    private final ConsumerSignalService consumerSignalService;
+    private final ConsumerHistoryService consumerHistoryService;
+
+    /**
+     * Analyze a suspicious signal reported by a consumer app/extension.
+     * POST /api/consumer/analyze
+     */
+    @PostMapping("/analyze")
+    public ResponseEntity<ApiResponse<ConsumerAnalysisResponse>> analyze(
+            @Valid @RequestBody ConsumerSignalRequest request) {
+
+        log.info("Consumer analysis request received for channel: {}", request.getChannel());
+        ConsumerAnalysisResponse response = consumerSignalService.analyzeSignal(request);
+
+        return ApiResponse.ok(response, "Consumer signal analyzed successfully");
+    }
+
+    /**
+     * List recent consumer analysis sessions.
+     * GET /api/consumer/history?limit=20
+     */
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<List<ConsumerHistoryItemResponse>>> listHistory(
+            @RequestParam(defaultValue = "20") int limit) {
+
+        List<ConsumerHistoryItemResponse> historyItems = consumerHistoryService.getRecentHistory(limit);
+        return ApiResponse.ok(historyItems, "Consumer history retrieved successfully");
+    }
+
+    /**
+     * Get detail of one consumer analysis session.
+     * GET /api/consumer/history/{sessionId}
+     */
+    @GetMapping("/history/{sessionId}")
+    public ResponseEntity<ApiResponse<ConsumerHistoryDetailResponse>> getHistoryDetail(
+            @PathVariable String sessionId) {
+
+        ConsumerHistoryDetailResponse detail = consumerHistoryService.getHistoryDetail(sessionId);
+        return ApiResponse.ok(detail, "Consumer history detail retrieved successfully");
+    }
+}

--- a/src/main/java/com/varutri/honeypot/dto/ConsumerAnalysisResponse.java
+++ b/src/main/java/com/varutri/honeypot/dto/ConsumerAnalysisResponse.java
@@ -1,0 +1,44 @@
+package com.varutri.honeypot.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Consumer-friendly analysis response for mobile and extension clients.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConsumerAnalysisResponse {
+
+    private String sessionId;
+    private String analysisTimestamp;
+    private String channel;
+    private Verdict verdict;
+    private boolean reportRecommended;
+
+    private ThreatAssessmentResponse threatAssessment;
+    private ExtractedInfo extractedInfo;
+
+    @Builder.Default
+    private List<String> recommendedActions = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> platformNotes = new ArrayList<>();
+
+    private String analyzedTextPreview;
+
+    public enum Verdict {
+        SAFE,
+        SUSPICIOUS,
+        DANGER
+    }
+}

--- a/src/main/java/com/varutri/honeypot/dto/ConsumerAuthTokenRequest.java
+++ b/src/main/java/com/varutri/honeypot/dto/ConsumerAuthTokenRequest.java
@@ -1,0 +1,36 @@
+package com.varutri.honeypot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request payload for issuing short-lived consumer bearer tokens.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerAuthTokenRequest {
+
+    @NotBlank(message = "App ID is required")
+    @Size(max = 100, message = "App ID cannot exceed 100 characters")
+    @Pattern(regexp = "^[a-zA-Z0-9._-]+$", message = "App ID contains invalid characters")
+    private String appId;
+
+    @NotBlank(message = "Device ID is required")
+    @Size(max = 180, message = "Device ID cannot exceed 180 characters")
+    @Pattern(regexp = "^[a-zA-Z0-9._:-]+$", message = "Device ID contains invalid characters")
+    private String deviceId;
+
+    @NotBlank(message = "Platform is required")
+    @Size(max = 30, message = "Platform cannot exceed 30 characters")
+    @Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "Platform contains invalid characters")
+    private String platform;
+
+    @Size(max = 40, message = "App version cannot exceed 40 characters")
+    @Pattern(regexp = "^[a-zA-Z0-9._-]*$", message = "App version contains invalid characters")
+    private String appVersion;
+}

--- a/src/main/java/com/varutri/honeypot/dto/ConsumerAuthTokenResponse.java
+++ b/src/main/java/com/varutri/honeypot/dto/ConsumerAuthTokenResponse.java
@@ -1,0 +1,23 @@
+package com.varutri.honeypot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response payload for consumer bearer token issuance.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerAuthTokenResponse {
+    private String tokenType;
+    private String accessToken;
+    private long expiresAtEpochMs;
+    private long expiresInSeconds;
+    private String appId;
+    private String deviceId;
+    private String platform;
+}

--- a/src/main/java/com/varutri/honeypot/dto/ConsumerHistoryDetailResponse.java
+++ b/src/main/java/com/varutri/honeypot/dto/ConsumerHistoryDetailResponse.java
@@ -1,0 +1,40 @@
+package com.varutri.honeypot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Detailed consumer session history view for app detail pages.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerHistoryDetailResponse {
+    private String sessionId;
+    private String channel;
+    private ConsumerAnalysisResponse.Verdict verdict;
+    private String threatLevel;
+    private double threatScore;
+    private String firstSeen;
+    private String lastUpdated;
+    private ExtractedInfo extractedInfo;
+
+    @Builder.Default
+    private List<ConversationEntry> conversation = new ArrayList<>();
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConversationEntry {
+        private String sender;
+        private String text;
+        private Long timestamp;
+    }
+}

--- a/src/main/java/com/varutri/honeypot/dto/ConsumerHistoryItemResponse.java
+++ b/src/main/java/com/varutri/honeypot/dto/ConsumerHistoryItemResponse.java
@@ -1,0 +1,25 @@
+package com.varutri.honeypot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Summary list item for consumer analysis history timeline.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerHistoryItemResponse {
+    private String sessionId;
+    private String channel;
+    private ConsumerAnalysisResponse.Verdict verdict;
+    private String threatLevel;
+    private double threatScore;
+    private String lastUpdated;
+    private int messageCount;
+    private int indicatorCount;
+    private String lastMessagePreview;
+}

--- a/src/main/java/com/varutri/honeypot/dto/ConsumerSignalRequest.java
+++ b/src/main/java/com/varutri/honeypot/dto/ConsumerSignalRequest.java
@@ -1,0 +1,143 @@
+package com.varutri.honeypot.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Locale;
+
+/**
+ * Channel-aware consumer signal request for mobile apps, browser extensions,
+ * and share flows.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsumerSignalRequest {
+
+    @Size(min = 1, max = 100, message = "Session ID must be between 1 and 100 characters")
+    @Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "Session ID can only contain letters, numbers, underscores, and dashes")
+    private String sessionId;
+
+    @NotNull(message = "Channel is required")
+    private Channel channel;
+
+    @Valid
+    @NotNull(message = "Payload is required")
+    private SignalPayload payload;
+
+    @Valid
+    private Metadata metadata;
+
+    @AssertTrue(message = "At least one analyzable field is required")
+    public boolean hasAnalyzablePayload() {
+        if (payload == null) {
+            return false;
+        }
+        return hasText(payload.text)
+                || hasText(payload.callTranscript)
+                || hasText(payload.emailSubject)
+                || hasText(payload.senderId)
+                || hasText(payload.url)
+                || hasText(payload.additionalContext);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignalPayload {
+
+        @Size(max = 5000, message = "Text cannot exceed 5000 characters")
+        private String text;
+
+        @Size(max = 5000, message = "Call transcript cannot exceed 5000 characters")
+        private String callTranscript;
+
+        @Size(max = 500, message = "Email subject cannot exceed 500 characters")
+        private String emailSubject;
+
+        @Size(max = 256, message = "Sender ID cannot exceed 256 characters")
+        private String senderId;
+
+        @Size(max = 2048, message = "URL cannot exceed 2048 characters")
+        private String url;
+
+        @Size(max = 2000, message = "Additional context cannot exceed 2000 characters")
+        private String additionalContext;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Metadata {
+
+        private Platform platform;
+
+        @Size(max = 100, message = "Source app cannot exceed 100 characters")
+        private String sourceApp;
+
+        @Size(max = 10, message = "Locale cannot exceed 10 characters")
+        @Pattern(regexp = "^[a-zA-Z_-]*$", message = "Locale contains invalid characters")
+        private String locale;
+
+        @Size(max = 100, message = "Device model cannot exceed 100 characters")
+        private String deviceModel;
+    }
+
+    public enum Channel {
+        SMS,
+        CALL,
+        WHATSAPP,
+        EMAIL,
+        BROWSER,
+        MANUAL,
+        PROMPT,
+        OTHER;
+
+        @JsonCreator
+        public static Channel fromValue(String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            return Channel.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        }
+
+        @JsonValue
+        public String toValue() {
+            return name();
+        }
+    }
+
+    public enum Platform {
+        ANDROID,
+        IOS,
+        WEB,
+        EXTENSION,
+        DESKTOP,
+        OTHER;
+
+        @JsonCreator
+        public static Platform fromValue(String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            return Platform.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        }
+
+        @JsonValue
+        public String toValue() {
+            return name();
+        }
+    }
+}

--- a/src/main/java/com/varutri/honeypot/security/ApiKeyFilter.java
+++ b/src/main/java/com/varutri/honeypot/security/ApiKeyFilter.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  */
 @Slf4j
 @Component
-@Order(2) // Run after RateLimitFilter (which is Order 1)
+@Order(3) // Runs after consumer token filter
 public class ApiKeyFilter extends OncePerRequestFilter {
 
     @Value("${varutri.api-key}")
@@ -34,9 +34,10 @@ public class ApiKeyFilter extends OncePerRequestFilter {
 
         String requestApiKey = request.getHeader(API_KEY_HEADER);
 
-        // Allow health check endpoint without API key
-        if (request.getRequestURI().contains("/actuator") ||
-                request.getRequestURI().contains("/health")) {
+        String path = request.getRequestURI();
+
+        // Allow health and consumer endpoints without API key
+        if (isExemptPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -63,5 +64,11 @@ public class ApiKeyFilter extends OncePerRequestFilter {
 
         log.debug("API key validated successfully");
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isExemptPath(String path) {
+        return path.contains("/actuator")
+                || path.contains("/health")
+                || path.startsWith("/api/consumer");
     }
 }

--- a/src/main/java/com/varutri/honeypot/security/ConsumerTokenFilter.java
+++ b/src/main/java/com/varutri/honeypot/security/ConsumerTokenFilter.java
@@ -1,0 +1,78 @@
+package com.varutri.honeypot.security;
+
+import com.varutri.honeypot.service.security.ConsumerTokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Enforces short-lived bearer tokens on consumer endpoints.
+ */
+@Slf4j
+@Component
+@Order(2)
+@RequiredArgsConstructor
+public class ConsumerTokenFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final ConsumerTokenService consumerTokenService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        if (!path.startsWith("/api/consumer")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (path.startsWith("/api/consumer/auth/token")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authorization = request.getHeader(AUTHORIZATION_HEADER);
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            writeError(response, HttpServletResponse.SC_UNAUTHORIZED,
+                    "Missing or invalid consumer bearer token");
+            return;
+        }
+
+        String token = authorization.substring(BEARER_PREFIX.length()).trim();
+        var claims = consumerTokenService.validateToken(token);
+        if (claims.isEmpty()) {
+            writeError(response, HttpServletResponse.SC_FORBIDDEN,
+                    "Consumer bearer token is invalid or expired");
+            return;
+        }
+
+        request.setAttribute("consumerDeviceId", claims.get().getDeviceId());
+        request.setAttribute("consumerAppId", claims.get().getAppId());
+        request.setAttribute("consumerPlatform", claims.get().getPlatform());
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void writeError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"success\":false,\"status\":" + status
+                + ",\"message\":\"Unauthorized\",\"error\":{\"code\":\"CONSUMER_TOKEN_ERROR\",\"details\":\""
+                + message + "\"}}");
+        log.warn("Consumer token auth failed: {}", message);
+    }
+}

--- a/src/main/java/com/varutri/honeypot/service/core/ConsumerHistoryService.java
+++ b/src/main/java/com/varutri/honeypot/service/core/ConsumerHistoryService.java
@@ -1,0 +1,232 @@
+package com.varutri.honeypot.service.core;
+
+import com.varutri.honeypot.dto.ConsumerAnalysisResponse;
+import com.varutri.honeypot.dto.ConsumerHistoryDetailResponse;
+import com.varutri.honeypot.dto.ConsumerHistoryItemResponse;
+import com.varutri.honeypot.dto.ExtractedInfo;
+import com.varutri.honeypot.entity.EvidenceEntity;
+import com.varutri.honeypot.entity.SessionEntity;
+import com.varutri.honeypot.exception.ResourceNotFoundException;
+import com.varutri.honeypot.repository.EvidenceRepository;
+import com.varutri.honeypot.repository.SessionRepository;
+import com.varutri.honeypot.service.security.InputSanitizer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Provides consumer session history list and detail views.
+ */
+@Service
+@RequiredArgsConstructor
+public class ConsumerHistoryService {
+
+    private final SessionRepository sessionRepository;
+    private final EvidenceRepository evidenceRepository;
+    private final InputSanitizer inputSanitizer;
+
+    public List<ConsumerHistoryItemResponse> getRecentHistory(int requestedLimit) {
+        int limit = Math.max(1, Math.min(requestedLimit, 100));
+
+        return sessionRepository.findAll().stream()
+                .filter(this::isConsumerSession)
+                .sorted(Comparator.comparing(SessionEntity::getUpdatedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+                .limit(limit)
+                .map(this::toHistoryItem)
+                .toList();
+    }
+
+    public ConsumerHistoryDetailResponse getHistoryDetail(String sessionId) {
+        String safeSessionId = inputSanitizer.sanitizeSessionId(sessionId);
+
+        SessionEntity session = sessionRepository.findBySessionId(safeSessionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Consumer session", safeSessionId));
+
+        if (!isConsumerSession(session)) {
+            throw new ResourceNotFoundException("Consumer session", safeSessionId);
+        }
+
+        Optional<EvidenceEntity> evidenceOpt = evidenceRepository.findBySessionId(safeSessionId);
+        EvidenceEntity evidence = evidenceOpt.orElse(null);
+
+        double threatScore = evidence != null ? evidence.getThreatLevel() : 0.0;
+        String threatLevel = deriveThreatLevel(threatScore);
+        ConsumerAnalysisResponse.Verdict verdict = mapVerdict(threatScore);
+
+        List<ConsumerHistoryDetailResponse.ConversationEntry> conversation = new ArrayList<>();
+        if (session.getConversationHistory() != null) {
+            conversation = session.getConversationHistory().stream()
+                    .map(msg -> ConsumerHistoryDetailResponse.ConversationEntry.builder()
+                            .sender(msg.getSender())
+                            .text(msg.getText())
+                            .timestamp(msg.getTimestamp())
+                            .build())
+                    .toList();
+        }
+
+        return ConsumerHistoryDetailResponse.builder()
+                .sessionId(safeSessionId)
+                .channel(detectChannel(session))
+                .verdict(verdict)
+                .threatLevel(threatLevel)
+                .threatScore(Math.round(threatScore * 100.0) / 100.0)
+                .firstSeen(session.getCreatedAt() != null ? session.getCreatedAt().toString() : null)
+                .lastUpdated(session.getUpdatedAt() != null ? session.getUpdatedAt().toString() : null)
+                .extractedInfo(mapExtractedInfo(evidence))
+                .conversation(conversation)
+                .build();
+    }
+
+    private ConsumerHistoryItemResponse toHistoryItem(SessionEntity session) {
+        Optional<EvidenceEntity> evidenceOpt = evidenceRepository.findBySessionId(session.getSessionId());
+        EvidenceEntity evidence = evidenceOpt.orElse(null);
+
+        double threatScore = evidence != null ? evidence.getThreatLevel() : 0.0;
+        String threatLevel = deriveThreatLevel(threatScore);
+        ConsumerAnalysisResponse.Verdict verdict = mapVerdict(threatScore);
+
+        return ConsumerHistoryItemResponse.builder()
+                .sessionId(session.getSessionId())
+                .channel(detectChannel(session))
+                .verdict(verdict)
+                .threatLevel(threatLevel)
+                .threatScore(Math.round(threatScore * 100.0) / 100.0)
+                .lastUpdated(session.getUpdatedAt() != null ? session.getUpdatedAt().toString() : null)
+                .messageCount(session.getConversationHistory() != null ? session.getConversationHistory().size() : 0)
+                .indicatorCount(countIndicators(evidence))
+                .lastMessagePreview(getLastMessagePreview(session))
+                .build();
+    }
+
+    private boolean isConsumerSession(SessionEntity session) {
+        if (session == null || session.getConversationHistory() == null || session.getConversationHistory().isEmpty()) {
+            return false;
+        }
+
+        if (session.getSessionId() != null && session.getSessionId().startsWith("consumer-")) {
+            return true;
+        }
+
+        SessionEntity.ConversationMessage firstMessage = session.getConversationHistory().get(0);
+        if (firstMessage == null || firstMessage.getText() == null) {
+            return false;
+        }
+
+        return firstMessage.getText().toLowerCase(Locale.ROOT).startsWith("channel:");
+    }
+
+    private String detectChannel(SessionEntity session) {
+        if (session.getConversationHistory() == null || session.getConversationHistory().isEmpty()) {
+            return "UNKNOWN";
+        }
+
+        String text = session.getConversationHistory().get(0).getText();
+        if (text == null) {
+            return "UNKNOWN";
+        }
+
+        String lower = text.toLowerCase(Locale.ROOT);
+        String prefix = "channel:";
+        int idx = lower.indexOf(prefix);
+        if (idx < 0) {
+            return "UNKNOWN";
+        }
+
+        String candidate = text.substring(idx + prefix.length()).trim();
+        int newlineIndex = candidate.indexOf('\n');
+        if (newlineIndex >= 0) {
+            candidate = candidate.substring(0, newlineIndex);
+        }
+
+        candidate = candidate.trim();
+        return candidate.isBlank() ? "UNKNOWN" : candidate.toUpperCase(Locale.ROOT);
+    }
+
+    private String getLastMessagePreview(SessionEntity session) {
+        if (session.getConversationHistory() == null || session.getConversationHistory().isEmpty()) {
+            return null;
+        }
+
+        SessionEntity.ConversationMessage last =
+                session.getConversationHistory().get(session.getConversationHistory().size() - 1);
+        if (last == null || last.getText() == null) {
+            return null;
+        }
+
+        String preview = last.getText().replace('\n', ' ').trim();
+        if (preview.length() > 140) {
+            return preview.substring(0, 140) + "...";
+        }
+        return preview;
+    }
+
+    private int countIndicators(EvidenceEntity evidence) {
+        if (evidence == null || evidence.getExtractedInfo() == null) {
+            return 0;
+        }
+
+        EvidenceEntity.ExtractedIntelligence info = evidence.getExtractedInfo();
+        return sizeOf(info.getUpiIds())
+                + sizeOf(info.getBankAccountNumbers())
+                + sizeOf(info.getPhoneNumbers())
+                + sizeOf(info.getUrls())
+                + sizeOf(info.getEmails());
+    }
+
+    private int sizeOf(List<String> list) {
+        return list == null ? 0 : list.size();
+    }
+
+    private String deriveThreatLevel(double threatScore) {
+        if (threatScore >= 0.85) {
+            return "CRITICAL";
+        }
+        if (threatScore >= 0.70) {
+            return "HIGH";
+        }
+        if (threatScore >= 0.40) {
+            return "MEDIUM";
+        }
+        if (threatScore >= 0.20) {
+            return "LOW";
+        }
+        return "SAFE";
+    }
+
+    private ConsumerAnalysisResponse.Verdict mapVerdict(double threatScore) {
+        if (threatScore >= 0.70) {
+            return ConsumerAnalysisResponse.Verdict.DANGER;
+        }
+        if (threatScore >= 0.30) {
+            return ConsumerAnalysisResponse.Verdict.SUSPICIOUS;
+        }
+        return ConsumerAnalysisResponse.Verdict.SAFE;
+    }
+
+    private ExtractedInfo mapExtractedInfo(EvidenceEntity evidence) {
+        if (evidence == null || evidence.getExtractedInfo() == null) {
+            return new ExtractedInfo();
+        }
+
+        EvidenceEntity.ExtractedIntelligence src = evidence.getExtractedInfo();
+        ExtractedInfo out = new ExtractedInfo();
+        out.setUpiIds(src.getUpiIds() != null ? new ArrayList<>(src.getUpiIds()) : new ArrayList<>());
+        out.setBankAccountNumbers(src.getBankAccountNumbers() != null
+                ? new ArrayList<>(src.getBankAccountNumbers())
+                : new ArrayList<>());
+        out.setIfscCodes(src.getIfscCodes() != null ? new ArrayList<>(src.getIfscCodes()) : new ArrayList<>());
+        out.setPhoneNumbers(src.getPhoneNumbers() != null ? new ArrayList<>(src.getPhoneNumbers()) : new ArrayList<>());
+        out.setUrls(src.getUrls() != null ? new ArrayList<>(src.getUrls()) : new ArrayList<>());
+        out.setEmails(src.getEmails() != null ? new ArrayList<>(src.getEmails()) : new ArrayList<>());
+        out.setSuspiciousKeywords(src.getSuspiciousKeywords() != null
+                ? new ArrayList<>(src.getSuspiciousKeywords())
+                : new ArrayList<>());
+        return out;
+    }
+}

--- a/src/main/java/com/varutri/honeypot/service/core/ConsumerSignalService.java
+++ b/src/main/java/com/varutri/honeypot/service/core/ConsumerSignalService.java
@@ -1,0 +1,218 @@
+package com.varutri.honeypot.service.core;
+
+import com.varutri.honeypot.dto.ConsumerAnalysisResponse;
+import com.varutri.honeypot.dto.ConsumerSignalRequest;
+import com.varutri.honeypot.dto.ExtractedInfo;
+import com.varutri.honeypot.dto.ThreatAssessmentResponse;
+import com.varutri.honeypot.service.ai.EnsembleThreatScorer;
+import com.varutri.honeypot.service.ai.InformationExtractor;
+import com.varutri.honeypot.service.data.EvidenceCollector;
+import com.varutri.honeypot.service.data.SessionStore;
+import com.varutri.honeypot.service.security.InputSanitizer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Orchestrates channel-aware consumer signal analysis for mobile and extension clients.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConsumerSignalService {
+
+    private final EnsembleThreatScorer ensembleThreatScorer;
+    private final InformationExtractor informationExtractor;
+    private final SessionStore sessionStore;
+    private final EvidenceCollector evidenceCollector;
+    private final InputSanitizer inputSanitizer;
+
+    public ConsumerAnalysisResponse analyzeSignal(ConsumerSignalRequest request) {
+        String sessionId = resolveSessionId(request.getSessionId(), request.getChannel());
+        String analyzableText = buildAnalyzableText(request);
+
+        String sanitizedText = inputSanitizer.sanitizeMessageText(analyzableText);
+        if (sanitizedText == null || sanitizedText.isBlank()) {
+            throw new IllegalArgumentException("No analyzable text could be derived from payload");
+        }
+
+        log.info("Consumer signal analysis started: session={}, channel={}, contentLength={}",
+                sessionId, request.getChannel(), sanitizedText.length());
+
+        if (inputSanitizer.containsPromptInjection(sanitizedText)) {
+            log.warn("Potential prompt-injection style content detected in consumer signal: {}",
+                    inputSanitizer.sanitizeForLogging(sessionId));
+        }
+
+        EnsembleThreatScorer.ThreatAssessment assessment =
+                ensembleThreatScorer.assessThreat(sanitizedText, new ArrayList<>());
+
+        ExtractedInfo extractedInfo = informationExtractor.extractInformation(sanitizedText);
+
+        persistAnalysisArtifacts(sessionId, sanitizedText, assessment);
+
+        ConsumerAnalysisResponse.Verdict verdict = mapVerdict(assessment.getThreatLevel());
+        List<String> recommendedActions = buildRecommendedActions(request.getChannel(), verdict, extractedInfo);
+        List<String> platformNotes = buildPlatformNotes(request.getMetadata(), request.getChannel());
+
+        log.info("Consumer signal analyzed: session={}, verdict={}, threatLevel={}, score={}",
+                sessionId, verdict, assessment.getThreatLevel(), assessment.getEnsembleScore());
+
+        return ConsumerAnalysisResponse.builder()
+                .sessionId(sessionId)
+                .analysisTimestamp(Instant.now().toString())
+                .channel(request.getChannel().name())
+                .verdict(verdict)
+                .reportRecommended(assessment.isHighThreat())
+                .threatAssessment(ThreatAssessmentResponse.fromAssessment(assessment))
+                .extractedInfo(extractedInfo)
+                .recommendedActions(recommendedActions)
+                .platformNotes(platformNotes)
+                .analyzedTextPreview(buildPreview(sanitizedText))
+                .build();
+    }
+
+    private String resolveSessionId(String incomingSessionId, ConsumerSignalRequest.Channel channel) {
+        if (incomingSessionId != null && !incomingSessionId.isBlank()) {
+            return inputSanitizer.sanitizeSessionId(incomingSessionId);
+        }
+        String generated = "consumer-" + channel.name().toLowerCase() + "-" + System.currentTimeMillis();
+        return inputSanitizer.sanitizeSessionId(generated);
+    }
+
+    private String buildAnalyzableText(ConsumerSignalRequest request) {
+        ConsumerSignalRequest.SignalPayload payload = request.getPayload();
+        StringBuilder text = new StringBuilder();
+
+        text.append("channel: ").append(request.getChannel().name()).append("\n");
+
+        appendIfPresent(text, "text", payload.getText());
+        appendIfPresent(text, "callTranscript", payload.getCallTranscript());
+        appendIfPresent(text, "emailSubject", payload.getEmailSubject());
+        appendIfPresent(text, "senderId", payload.getSenderId());
+        appendIfPresent(text, "url", payload.getUrl());
+        appendIfPresent(text, "additionalContext", payload.getAdditionalContext());
+
+        if (request.getMetadata() != null) {
+            appendIfPresent(text, "platform", request.getMetadata().getPlatform() != null
+                    ? request.getMetadata().getPlatform().name()
+                    : null);
+            appendIfPresent(text, "sourceApp", request.getMetadata().getSourceApp());
+            appendIfPresent(text, "locale", request.getMetadata().getLocale());
+        }
+
+        return text.toString();
+    }
+
+    private void appendIfPresent(StringBuilder builder, String label, String value) {
+        if (value != null && !value.isBlank()) {
+            builder.append(label).append(": ").append(value.trim()).append("\n");
+        }
+    }
+
+    private void persistAnalysisArtifacts(String sessionId,
+            String analyzableText,
+            EnsembleThreatScorer.ThreatAssessment assessment) {
+        try {
+            sessionStore.addMessage(sessionId, "user", analyzableText);
+            sessionStore.addMessage(sessionId, "assistant", createSystemSummary(assessment));
+            evidenceCollector.collectEvidence(sessionId, analyzableText, createSystemSummary(assessment));
+        } catch (Exception ex) {
+            log.warn("Failed to persist consumer analysis artifacts for {}: {}",
+                    inputSanitizer.sanitizeForLogging(sessionId), ex.getMessage());
+        }
+    }
+
+    private String createSystemSummary(EnsembleThreatScorer.ThreatAssessment assessment) {
+        return String.format("Consumer signal classified as %s (%s, %.0f%% confidence)",
+                assessment.getThreatLevel(),
+                assessment.getPrimaryScamType(),
+                assessment.getCalibratedConfidence() * 100);
+    }
+
+    private ConsumerAnalysisResponse.Verdict mapVerdict(String threatLevel) {
+        if (threatLevel == null) {
+            return ConsumerAnalysisResponse.Verdict.SUSPICIOUS;
+        }
+        return switch (threatLevel) {
+            case "HIGH", "CRITICAL" -> ConsumerAnalysisResponse.Verdict.DANGER;
+            case "SAFE" -> ConsumerAnalysisResponse.Verdict.SAFE;
+            default -> ConsumerAnalysisResponse.Verdict.SUSPICIOUS;
+        };
+    }
+
+    private List<String> buildRecommendedActions(ConsumerSignalRequest.Channel channel,
+            ConsumerAnalysisResponse.Verdict verdict,
+            ExtractedInfo extractedInfo) {
+        List<String> actions = new ArrayList<>();
+
+        switch (verdict) {
+            case DANGER -> {
+                actions.add("Do not reply, pay, or share OTP/PIN/card details.");
+                actions.add("Block the sender and preserve screenshots for reporting.");
+                actions.add("Report urgently to cybercrime helpline/portal in your region.");
+            }
+            case SUSPICIOUS -> {
+                actions.add("Pause and verify through official channels before taking action.");
+                actions.add("Do not click links or install apps shared by unknown contacts.");
+            }
+            case SAFE -> actions.add("No clear scam signal detected, but continue normal caution.");
+        }
+
+        if (extractedInfo != null && extractedInfo.getUrls() != null && !extractedInfo.getUrls().isEmpty()) {
+            actions.add("Detected URL indicators: avoid opening links until verified.");
+        }
+        if (channel == ConsumerSignalRequest.Channel.CALL) {
+            actions.add("Never install remote-control apps requested during a call.");
+        }
+        if (channel == ConsumerSignalRequest.Channel.EMAIL) {
+            actions.add("Verify sender domain and watch for lookalike addresses.");
+        }
+        if (channel == ConsumerSignalRequest.Channel.WHATSAPP) {
+            actions.add("Forward suspicious chat to your verified protection number for follow-up.");
+        }
+        if (channel == ConsumerSignalRequest.Channel.PROMPT) {
+            actions.add("Do not execute untrusted prompts or shell commands without review.");
+        }
+
+        return actions;
+    }
+
+    private List<String> buildPlatformNotes(ConsumerSignalRequest.Metadata metadata,
+            ConsumerSignalRequest.Channel channel) {
+        List<String> notes = new ArrayList<>();
+
+        if (metadata == null || metadata.getPlatform() == null) {
+            return notes;
+        }
+
+        if (metadata.getPlatform() == ConsumerSignalRequest.Platform.IOS
+                && channel == ConsumerSignalRequest.Channel.SMS) {
+            notes.add("iOS apps cannot read full SMS inbox. Analysis uses shared text or filter-extension context.");
+        }
+
+        if (metadata.getPlatform() == ConsumerSignalRequest.Platform.IOS
+                && channel == ConsumerSignalRequest.Channel.CALL) {
+            notes.add("iOS call protection is caller-ID/block-list based, not full call-log ingestion.");
+        }
+
+        if (metadata.getPlatform() == ConsumerSignalRequest.Platform.ANDROID
+                && (channel == ConsumerSignalRequest.Channel.SMS || channel == ConsumerSignalRequest.Channel.CALL)) {
+            notes.add("Android deep SMS/Call automation may require default-handler role and policy-compliant permission declarations.");
+        }
+
+        return notes;
+    }
+
+    private String buildPreview(String text) {
+        String preview = text.replace('\n', ' ').trim();
+        if (preview.length() > 220) {
+            return preview.substring(0, 220) + "...";
+        }
+        return preview;
+    }
+}

--- a/src/main/java/com/varutri/honeypot/service/security/ConsumerTokenService.java
+++ b/src/main/java/com/varutri/honeypot/service/security/ConsumerTokenService.java
@@ -1,0 +1,175 @@
+package com.varutri.honeypot.service.security;
+
+import com.varutri.honeypot.dto.ConsumerAuthTokenRequest;
+import com.varutri.honeypot.dto.ConsumerAuthTokenResponse;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Issues and validates short-lived consumer bearer tokens.
+ */
+@Slf4j
+@Service
+public class ConsumerTokenService {
+
+    @Value("${consumer.auth.token.secret:${VARUTRI_API_KEY:dev-consumer-secret-change-me}}")
+    private String tokenSecret;
+
+    @Value("${consumer.auth.token.ttl-minutes:240}")
+    private long tokenTtlMinutes;
+
+    @Value("${consumer.auth.allowed-app-ids:varutri-mobile,varutri-extension,varutri-web}")
+    private String allowedAppIdsCsv;
+
+    public ConsumerAuthTokenResponse issueToken(ConsumerAuthTokenRequest request) {
+        String normalizedAppId = request.getAppId().trim().toLowerCase(Locale.ROOT);
+        String normalizedDeviceId = request.getDeviceId().trim();
+        String normalizedPlatform = request.getPlatform().trim().toUpperCase(Locale.ROOT);
+
+        validateAppId(normalizedAppId);
+
+        long issuedAt = Instant.now().toEpochMilli();
+        long expiresAt = issuedAt + (tokenTtlMinutes * 60_000);
+
+        String payload = String.join("|",
+                normalizedAppId,
+                normalizedDeviceId,
+                normalizedPlatform,
+                String.valueOf(issuedAt),
+                String.valueOf(expiresAt));
+
+        String encodedPayload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        String signature = sign(encodedPayload);
+        String token = encodedPayload + "." + signature;
+
+        long expiresInSeconds = Math.max((expiresAt - Instant.now().toEpochMilli()) / 1000, 0);
+
+        return ConsumerAuthTokenResponse.builder()
+                .tokenType("Bearer")
+                .accessToken(token)
+                .expiresAtEpochMs(expiresAt)
+                .expiresInSeconds(expiresInSeconds)
+                .appId(normalizedAppId)
+                .deviceId(normalizedDeviceId)
+                .platform(normalizedPlatform)
+                .build();
+    }
+
+    public Optional<TokenClaims> validateToken(String token) {
+        if (token == null || token.isBlank() || !token.contains(".")) {
+            return Optional.empty();
+        }
+
+        String[] parts = token.split("\\.", 2);
+        if (parts.length != 2) {
+            return Optional.empty();
+        }
+
+        String encodedPayload = parts[0];
+        String providedSignature = parts[1];
+
+        String expectedSignature = sign(encodedPayload);
+        if (!java.security.MessageDigest.isEqual(
+                expectedSignature.getBytes(StandardCharsets.UTF_8),
+                providedSignature.getBytes(StandardCharsets.UTF_8))) {
+            return Optional.empty();
+        }
+
+        String payload;
+        try {
+            payload = new String(Base64.getUrlDecoder().decode(encodedPayload), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+
+        String[] fields = payload.split("\\|", 5);
+        if (fields.length != 5) {
+            return Optional.empty();
+        }
+
+        String appId = fields[0];
+        String deviceId = fields[1];
+        String platform = fields[2];
+
+        long issuedAt;
+        long expiresAt;
+        try {
+            issuedAt = Long.parseLong(fields[3]);
+            expiresAt = Long.parseLong(fields[4]);
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+
+        if (Instant.now().toEpochMilli() > expiresAt) {
+            return Optional.empty();
+        }
+
+        if (!isAllowedAppId(appId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TokenClaims(appId, deviceId, platform, issuedAt, expiresAt));
+    }
+
+    private void validateAppId(String appId) {
+        if (!isAllowedAppId(appId)) {
+            throw new IllegalArgumentException("Unsupported consumer app ID: " + appId);
+        }
+    }
+
+    private boolean isAllowedAppId(String appId) {
+        List<String> allowed = parseAllowedAppIds();
+        return allowed.contains(appId);
+    }
+
+    private List<String> parseAllowedAppIds() {
+        List<String> ids = new ArrayList<>();
+        if (allowedAppIdsCsv == null || allowedAppIdsCsv.isBlank()) {
+            return ids;
+        }
+        for (String raw : allowedAppIdsCsv.split(",")) {
+            String trimmed = raw.trim().toLowerCase(Locale.ROOT);
+            if (!trimmed.isBlank()) {
+                ids.add(trimmed);
+            }
+        }
+        return ids;
+    }
+
+    private String sign(String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec keySpec = new SecretKeySpec(tokenSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            mac.init(keySpec);
+            byte[] signature = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(signature);
+        } catch (Exception ex) {
+            log.error("Failed to sign consumer token", ex);
+            throw new IllegalStateException("Failed to sign consumer token");
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class TokenClaims {
+        private String appId;
+        private String deviceId;
+        private String platform;
+        private long issuedAtEpochMs;
+        private long expiresAtEpochMs;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,11 @@ llm.provider=huggingface
 # Security Configuration (loaded from .env)
 varutri.api-key=${VARUTRI_API_KEY}
 
+# Consumer token auth (short-lived bearer tokens for mobile/extension clients)
+consumer.auth.token.secret=${CONSUMER_AUTH_TOKEN_SECRET:${VARUTRI_API_KEY}}
+consumer.auth.token.ttl-minutes=240
+consumer.auth.allowed-app-ids=varutri-mobile,varutri-extension,varutri-web
+
 # ===========================================
 # Local ML Model Configuration (DJL)
 # ===========================================

--- a/test-api.sh
+++ b/test-api.sh
@@ -7,7 +7,7 @@ echo ""
 
 # Test 1: Health check
 echo "1. Testing health endpoint..."
-curl -s http://localhost:8080/health
+curl -s http://localhost:8080/api/health
 echo -e "\n"
 
 # Test 2: Chat API
@@ -20,6 +20,47 @@ curl -X POST http://localhost:8080/api/chat \
     "message": "Hello",
     "conversationHistory": []
   }'
+echo -e "\n"
+
+# Test 3: Consumer Analysis API
+echo "3. Testing consumer analysis endpoint..."
+
+TOKEN=$(curl -s -X POST http://localhost:8080/api/consumer/auth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "appId": "varutri-mobile",
+    "deviceId": "android-local-test-001",
+    "platform": "ANDROID",
+    "appVersion": "1.0.0"
+  }' | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p')
+
+if [ -z "$TOKEN" ]; then
+  echo "[ERROR] Failed to fetch consumer access token"
+  exit 1
+fi
+
+curl -X POST http://localhost:8080/api/consumer/analyze \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -d '{
+    "channel": "SMS",
+    "payload": {
+      "text": "Congratulations! Claim your lottery by sending 5000 to prize@paytm",
+      "senderId": "+919876543210",
+      "url": "http://fake-claim-now.example"
+    },
+    "metadata": {
+      "platform": "ANDROID",
+      "sourceApp": "messages",
+      "locale": "en_IN"
+    }
+  }'
+echo -e "\n"
+
+# Test 4: Consumer History API
+echo "4. Testing consumer history endpoint..."
+curl -s "http://localhost:8080/api/consumer/history?limit=5" \
+  -H "Authorization: Bearer ${TOKEN}"
 echo -e "\n"
 
 echo "Test complete!"


### PR DESCRIPTION
## What\n- add consumer token exchange endpoint at /api/consumer/auth/token\n- enforce Bearer token auth for /api/consumer/**\n- keep x-api-key path for non-consumer/admin endpoints\n- add consumer history endpoints:\n  - GET /api/consumer/history\n  - GET /api/consumer/history/{sessionId}\n- update README, QUICKSTART, and test-api.sh for token-based flow\n\n## Validation\n- mvn -q -DskipTests compile\n\nCloses #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer authentication endpoint to obtain short-lived bearer tokens with app credentials.
  * Added consumer signal analysis endpoint to analyze threats with channel, payload, and metadata inputs.
  * Added consumer history endpoints to retrieve recent and detailed analysis records.

* **Documentation**
  * Updated Quick Start guide with consumer API authentication and analysis workflow examples.
  * Updated README with consumer REST API documentation and complete endpoint reference.
  * Updated test scripts demonstrating consumer API usage with bearer token flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->